### PR TITLE
add download attribute to download link on orders page

### DIFF
--- a/imports/plugins/core/checkout/client/components/completedOrderItem.js
+++ b/imports/plugins/core/checkout/client/components/completedOrderItem.js
@@ -22,7 +22,11 @@ const CompletedOrderItem = ({ item, handleDisplayMedia }) => {
       <div className="order-details-title">{item.product.title}<p>{item.variants.title}</p>
         {
           item.product.isDigital &&
-          <a href={item.variants.downloadLink} className="btn btn-success btn-xs product-download-link" target="_blank">DOWNLOAD</a>
+          <a href={item.variants.downloadLink} download={item.variants.title} className="btn btn-success btn-xs product-download-link"
+            target="_blank"
+          >
+          DOWNLOAD
+          </a>
         }</div>
       <div className="order-details-quantity"><span>{item.quantity}</span></div>
       <div className="order-details-price"><Components.Currency amount={item.variants.price} /></div>


### PR DESCRIPTION
#### What does this PR do?
>- File should download to user device
#### Description of Task to be completed?
>- When user purchases a digital product, and clicks on the download button, it should download to the user's local device.
#### How should this be manually tested?
>- git clone this project @https://github.com/andela/blade-runner-rc.git
>- run meteor npm install to install all dependencies
>- run "reaction "to start the server
>- server would be up and running on localhost:3000
>- Complete an order
>- Download product

#### Any background context you want to provide?
>- N/A

#### What are the relevant pivotal tracker stories?
>- 154621260

#### Screenshots (if appropriate):
<img width="948" alt="screen shot 2018-02-28 at 10 11 38 am" src="https://user-images.githubusercontent.com/19477966/36779323-ebcf96ce-1c6f-11e8-9f12-f9900635ab2a.png">



#### Questions:
>- N/A